### PR TITLE
V3 Commands ft Command Functions

### DIFF
--- a/bot_functions/utilities_db.py
+++ b/bot_functions/utilities_db.py
@@ -33,7 +33,8 @@ class Praxis_DB_Connection():
         self.credentials_manager.load_credentials()
         self.dbCert: credentials.DB_Credential = self.credentials_manager.find_Credential(credentials.DB_Credential, config.credentialsNickname)
 
-        self.connectionString = "postgresql://%s:%s@%s/%s" % (self.dbCert.username, self.dbCert.password, self.dbCert.ipAddress, self.dbCert.databaseName)
+        #self.connectionString = "postgresql://%s:%s@%s/%s" % (self.dbCert.username, self.dbCert.password, self.dbCert.ipAddress, self.dbCert.databaseName)
+        self.connectionString = "postgresql://%s:%s@%s/%s" % (self.dbCert.username, self.dbCert.password, "localhost", self.dbCert.databaseName)
 
         self.dbConnection = None
         if autoConnect == True:
@@ -45,9 +46,23 @@ class Praxis_DB_Connection():
     def closeConnection(self):
         self.dbConnection = None
 
+    def doesTableExist(self, tableName):
+        try:
+            query = "SELECT to_regclass('%s');" % tableName
+            result = self.dbConnection.execute(query)
+            for r in result:
+                if r[0] == tableName:
+                    return True
+            return False
+
+        except:
+            print("[Praxis_DB_Connection] query error")
+            return False
+
     def execQuery(self, query):
         try:
-            return self.dbConnection.execute(query)
+            results = self.dbConnection.execute(query)
+            return results
         except:
             print("[Praxis_DB_Connection] query error")
             return None

--- a/commands/command_base.py
+++ b/commands/command_base.py
@@ -39,11 +39,11 @@ class AbstractCommand(metaclass=ABCMeta):
     """
 
     class CommandType(Enum):
-        NONE = auto()
-        Praxis = auto()
-        TWITCH = auto()
-        DISCORD = auto()
         Ver2 = auto()
+        Ver3 = auto()
+
+    class CommandFunction_Ver(Enum):
+        ONE = auto()
 
     class CommandSource(Enum):
         default = 0

--- a/commands/command_base.py
+++ b/commands/command_base.py
@@ -25,9 +25,10 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from abc import ABCMeta, abstractmethod
+from commands.command_functions import AbstractCommandFunction
 from enum import Enum, auto
 
-
+from commands import loader_functions as function_loader
 class AbstractCommand(metaclass=ABCMeta):
     """
     This is the base class for commands. In order to load a command a few conditions must be met:
@@ -39,11 +40,9 @@ class AbstractCommand(metaclass=ABCMeta):
     """
 
     class CommandType(Enum):
+        NONE = auto()
         Ver2 = auto()
         Ver3 = auto()
-
-    class CommandFunction_Ver(Enum):
-        ONE = auto()
 
     class CommandSource(Enum):
         default = 0
@@ -55,8 +54,10 @@ class AbstractCommand(metaclass=ABCMeta):
         self.command = command
         self.n_args = n_args
         self.command_type = command_type
-        self.help = helpText
+        self.helpText = helpText
         self.isCommandEnabled = CommandEnabled
+
+        self.loadedFunctions = function_loader.load_functions(AbstractCommandFunction.FunctionType.ver0)
 
     # no touch!
     def get_args(self, text: str) -> list:
@@ -72,7 +73,7 @@ class AbstractCommand(metaclass=ABCMeta):
 
     # no touch!
     def get_help(self):
-        return self.help
+        return self.helpText
 
     # no touch!
     def is_command_enabled(self):

--- a/commands/command_functions.py
+++ b/commands/command_functions.py
@@ -1,6 +1,11 @@
 from abc import ABCMeta, abstractmethod
 from enum import Enum, auto
 
+from json import loads
+from urllib.parse import urlencode
+import requests
+from bot_functions import utilities_db as db_utility
+
 class AbstractCommandFunction(metaclass=ABCMeta):
     class FunctionType(Enum):
         NONE = auto()
@@ -40,9 +45,19 @@ class AbstractCommandFunction(metaclass=ABCMeta):
         pass
 
 class Function_Helpers():
-    from json import loads
-    from urllib.parse import urlencode
-    import requests
+
+    def get_Command_returnString(self, command):
+        try:
+            db_obj = db_utility.Praxis_DB_Connection(autoConnect=True)
+            dbResults = db_obj.execQuery(
+                'SELECT * FROM '
+                'command_responses_v0;')
+            db_obj.closeConnection()
+            for i in dbResults:
+                return i[2]
+            #return dbResults
+        except:
+            return "UNABLE TO FIND RESPONSE"
 
     def send_Lights_Command(self, username, light_group, command, rest):
         # todo need to url-escape command and rest

--- a/commands/command_functions.py
+++ b/commands/command_functions.py
@@ -1,0 +1,78 @@
+from abc import ABCMeta, abstractmethod
+from enum import Enum, auto
+
+class AbstractCommandFunction(metaclass=ABCMeta):
+    class FunctionType(Enum):
+        NONE = auto()
+        ver0 = auto()
+
+
+    def __init__(
+            self,
+            functionName: str,
+            n_args: int = 0,
+            functionType = FunctionType.NONE,
+            helpText:list=["No Help"]
+        ):
+        self.functionName = functionName
+        self.n_args = n_args
+        self.functionType = functionType
+        self.helpText = helpText
+
+    # no touch!
+    def get_args(self, text: str) -> list:
+        return text.split(" ")[0:self.n_args + 1]
+
+    # no touch!
+    def get_name(self) -> str:
+        return self.functionName
+
+    # no touch!
+    def get_functionType(self):
+        return self.functionType
+
+    # no touch!
+    def get_help(self):
+        return self.helpText
+
+    @abstractmethod
+    def do_function(self, user, input):
+        pass
+
+class Function_Helpers():
+    from json import loads
+    from urllib.parse import urlencode
+    import requests
+
+    def send_Lights_Command(self, username, light_group, command, rest):
+        # todo need to url-escape command and rest
+        params = self.urlencode({'user_name': username, 'light_group': light_group, 'command': command, 'rest':rest})
+        #standalone_lights
+        url = "http://standalone_lights:42042/api/v1/exec_lights?%s" % params
+        resp = self.requests.get(url)
+        if resp.status_code == 200:
+            print("Got the following message: %s" % resp.text)
+            data = self.loads(resp.text)
+            msg = data['message']
+            if msg is not None:
+                return msg
+                # todo send to logger and other relevent services
+        else:
+            # todo handle failed requests
+            return None
+
+    def send_TTS(self, username, message):
+        params = self.urlencode({'tts_sender': username, 'tts_text': message})
+        #standalone_tts_core
+        url = "http://standalone_tts_core:42064/api/v1/tts/send_text?%s" % params
+        resp = self.requests.get(url)
+        if resp.status_code == 200:
+            print("Got the following message: %s" % resp.text)
+            data = self.loads(resp.text)
+            msg = data['message']
+            if msg is not None:
+                return msg
+                # todo send to logger and other relevent services
+        else:
+            # todo handle failed requests
+            pass

--- a/commands/implemented/Command_v3.py
+++ b/commands/implemented/Command_v3.py
@@ -1,0 +1,69 @@
+
+from abc import ABCMeta
+
+from json import loads
+from urllib.parse import urlencode
+import requests
+
+from commands.command_base import AbstractCommand
+from commands.command_functions import AbstractCommandFunction
+
+from bot_functions import utilities_script as utility
+
+import pyparsing
+
+
+class Command_v3(AbstractCommand, AbstractCommandFunction, metaclass=ABCMeta):
+    """
+    this is the v3 command.
+    """
+    command = "testerino_v3"
+    helpText = ["This is a v3 command.",
+        "\nExample:","testerino_v3"]
+
+    def __init__(self):
+        super().__init__(
+            Command_v3.command,
+            n_args=1,
+            command_type=AbstractCommand.CommandType.Ver3
+            )
+        self.helpText = Command_v3.helpText
+        self.isCommandEnabled = True
+
+    def do_command(self, source = AbstractCommand.CommandSource.default, user = "User",  command = "", rest = "", bonusData = None):
+
+        # Look up command in DB and get return strings.
+
+        # Proccess string and run functions
+        fullCommand = command + " " + rest # This creates the full command string.
+        functionsList = self.searchForFunctions(fullCommand) # Generates a list of functions to run in a specific order. Inner to Outer Most
+        for function in functionsList:
+            if function[2] == True:
+                pass
+            else:
+                self.run_function(user, function, fullCommand)
+
+        returnString = user + " sent: [ " + command + " ] with: " + rest
+        #print(returnString)
+
+
+        return returnString
+
+    def searchForFunctions(self, input):
+        parserContent = pyparsing.Word(pyparsing.alphanums)
+        parser = pyparsing.nestedExpr('(', ')', content=parserContent)
+        testResult_ = parser.parseString(input)
+        testResult = testResult_.asList()
+
+        #result1 = ("functionName", input, False)
+        #result2 = ("functionName2", ("functionName3", input, False, None), True)
+        #results = []
+        return testResult
+
+    def run_function(self, user, function, input):
+        function_:AbstractCommandFunction = self.loadedFunctions[function]
+        if function_ is not None:
+            function_response = function_.do_function(user, input)
+
+    def get_help(self):
+        return self.helpText

--- a/commands/implemented/Command_v3.py
+++ b/commands/implemented/Command_v3.py
@@ -6,20 +6,19 @@ from urllib.parse import urlencode
 import requests
 
 from commands.command_base import AbstractCommand
-from commands.command_functions import AbstractCommandFunction
+from commands.command_functions import AbstractCommandFunction, Function_Helpers
 
 from bot_functions import utilities_script as utility
 
 import pyparsing
 
-
 class Command_v3(AbstractCommand, AbstractCommandFunction, metaclass=ABCMeta):
     """
     this is the v3 command.
     """
-    command = "testerino_v3"
-    helpText = ["This is a v3 command.",
-        "\nExample:","testerino_v3"]
+    command = "base_v3"
+    helpText = ["This is the v3 command.",
+        "\nExample:","base_v3","base_v3 ARGZ"]
 
     def __init__(self):
         super().__init__(
@@ -31,14 +30,26 @@ class Command_v3(AbstractCommand, AbstractCommandFunction, metaclass=ABCMeta):
         self.isCommandEnabled = True
 
     def do_command(self, source = AbstractCommand.CommandSource.default, user = "User",  command = "", rest = "", bonusData = None):
+        # Command Example:
+        # Idea: "!roll #(0)" = "!roll d20"
+        # command = "!roll"
+        # rest = " #(0)" = " d20"
 
         # Look up command in DB and get return strings.
+        command_returnString = Function_Helpers.get_Command_returnString(command)
+        command_returnStringProcessed = ""
+        # example return string: "@(user) sent a message"
+        # example return string: "@(user) rolled $(roll #(0))"
 
-        # Proccess string and run functions
+
+        # Proccess strings
         fullCommand = command + " " + rest # This creates the full command string.
-        functionsList = self.searchForFunctions(fullCommand) # Generates a list of functions to run in a specific order. Inner to Outer Most
+        commandArguments = utility.get_args(rest)
+
+        functionsList = self.searchForFunctions(command_returnString) # Generates a list of functions to run in a specific order. Inner to Outer Most
+
         for function in functionsList:
-            if function[2] == True:
+            if function[2] == True: # If function contains a function
                 pass
             else:
                 self.run_function(user, function, fullCommand)
@@ -51,7 +62,7 @@ class Command_v3(AbstractCommand, AbstractCommandFunction, metaclass=ABCMeta):
 
     def searchForFunctions(self, input):
         parserContent = pyparsing.Word(pyparsing.alphanums)
-        parser = pyparsing.nestedExpr('(', ')', content=parserContent)
+        parser = pyparsing.nestedExpr('@(', ')')
         testResult_ = parser.parseString(input)
         testResult = testResult_.asList()
 
@@ -67,3 +78,6 @@ class Command_v3(AbstractCommand, AbstractCommandFunction, metaclass=ABCMeta):
 
     def get_help(self):
         return self.helpText
+
+    def do_function():
+        return None

--- a/commands/implemented_functions/function_test_v0.py
+++ b/commands/implemented_functions/function_test_v0.py
@@ -1,0 +1,41 @@
+from abc import ABCMeta
+
+from json import loads
+from urllib.parse import urlencode
+import requests
+
+from commands.command_base import AbstractCommand
+from commands.command_functions import AbstractCommandFunction
+
+from commands.command_functions import Function_Helpers
+
+from bot_functions import utilities_script as utility
+
+class Function_v0(AbstractCommandFunction, metaclass=ABCMeta):
+    """
+    This is v0 of Functions
+    """
+    functionName = "testFunction"
+    helpText = ["This is a v0 function.",
+        "\nExample:","testFunction"]
+
+    def __init__(self):
+        super().__init__(
+            functionName = Function_v0.functionName,
+            n_args=0,
+            functionType=AbstractCommandFunction.FunctionType.ver0,
+            helpText = Function_v0.helpText
+            )
+
+    def do_function(self, user, input):
+        self.input_check(input)
+        output = self.do_work(user, input)
+
+        return output
+
+    def do_work(self, user, input):
+        work = input
+        return work
+
+    def input_check():
+        return None

--- a/commands/loader_functions.py
+++ b/commands/loader_functions.py
@@ -1,0 +1,104 @@
+# The main repository of Praxis Bot can be found at: <https://github.com/TheCuriousNerd/Praxis-Bot>.
+# Copyright (C) 2021
+
+# Author Info Examples:
+#   Name / Email / Website
+#       Twitter / Twitch / Youtube / Github
+
+# Authors:
+#   Alex Orid / inquiries@thecuriousnerd.com / TheCuriousNerd.com
+#       Twitter: @TheCuriousNerd / Twitch: TheCuriousNerd / Youtube: thecuriousnerd / Github: TheCuriousNerd
+#   Virgil / hocestpotest@gmail.com
+#       Github: hoc-est-potest
+
+# This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import importlib
+import importlib.util
+import inspect
+import os
+import sys
+from typing import Dict
+
+from commands.command_functions import AbstractCommandFunction
+
+#New
+def load_functions(functionType: AbstractCommandFunction.FunctionType) -> Dict[str, AbstractCommandFunction]:
+    print(" -Loading ", functionType ," Functions...\n")
+    functions = compile_and_load(functionType)
+    return functions
+
+#New
+def compile_and_load_file(path: str, functionType: AbstractCommandFunction.FunctionType):
+    module_name = os.path.split(path)[1].replace(".py", "")
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.load_module(module_name)
+
+    for name, obj in inspect.getmembers(module):
+        if inspect.isclass(obj) and name.startswith("Command"):
+            function_inst = obj()
+            if functionType == function_inst.get_functionType():
+                print(" ---Successfully loaded %s: %s" % (functionType, function_inst.get_name()))
+                return function_inst.get_name(), function_inst
+            elif functionType != function_inst.get_functionType():
+                print(" -%s functionType did not match: %s for: %s" % (function_inst.get_functionType(), functionType, function_inst.get_name()))
+    return "", None
+
+
+#New
+def compile_and_load(functionType: AbstractCommandFunction.FunctionType) -> Dict[str, AbstractCommandFunction]:
+    dic = {}
+    implementations = get_implementations_dir()
+    for dirName, subdirList, fileList in os.walk(implementations):
+        for file in fileList:
+            name = os.path.join(dirName, file)
+            print("compiling: %s" % name)
+            name, function = compile_and_load_file(name, functionType)
+            if function is not None and function.get_functionType is functionType:
+                dic[name] = function
+        break
+    return dic
+
+def get_base_dir() -> str:
+    cwd = os.getcwd()
+    split = os.path.split(cwd)
+    current = split[len(split) - 1]
+    if current == 'commands':
+        return check_dir(cwd)
+    elif current == 'Praxis-Bot' or current == 'Praxis':
+        return check_dir(os.path.join(cwd, "commands"))
+    else:
+        print("could not find working directory for Praxis-Bot/commands")
+        raise Exception
+
+
+def get_implementations_dir() -> str:
+    return check_dir(os.path.join(get_base_dir(), "implemented_functions"))
+
+
+def get_compiled_dir() -> str:
+    return check_dir(os.path.join(get_base_dir(), "compiled"))
+
+
+def check_dir(path: str) -> str:
+    if not os.path.exists(path):
+        os.mkdir(path, 0x777)
+    return path
+
+
+if __name__ == "__main__":
+    cmds = load_functions()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ phue
 flask
 requests
 windyquery
+pyparsing

--- a/requirements_sa_command.txt
+++ b/requirements_sa_command.txt
@@ -6,3 +6,4 @@ psutil
 phue
 art
 requests
+pyparsing

--- a/temp-setup.bat
+++ b/temp-setup.bat
@@ -1,0 +1,2 @@
+docker build --file /standalone_command/Dockerfile --tag standalone_command .
+start powershell cd "standalone_command" ; docker-compose up -d ; cd ".."

--- a/temptest_2.py
+++ b/temptest_2.py
@@ -1,0 +1,31 @@
+import pyparsing
+
+def init():
+    stringToTest = "This is a $(test) command @(user)"
+    print(searchForFunctions1(stringToTest))
+    #print(searchForFunctions2(stringToTest))
+
+def searchForFunctions1(input):
+        parserContent = pyparsing.Word(pyparsing.alphanums)
+        parser = pyparsing.nestedExpr('$(', ')')
+        testResult_ = parser.parseString(input)
+        testResult = testResult_.asList()
+
+        #result1 = ("functionName", input, False)
+        #result2 = ("functionName2", ("functionName3", input, False, None), True)
+        #results = []
+        return testResult
+
+def searchForFunctions2(input):
+        parserContent = pyparsing.Word(pyparsing.alphanums)
+        parser = pyparsing.nestedExpr('@(', ')')
+        testResult_ = parser.parseString(input)
+        testResult = testResult_.asList()
+
+        #result1 = ("functionName", input, False)
+        #result2 = ("functionName2", ("functionName3", input, False, None), True)
+        #results = []
+        return testResult
+
+if __name__ == '__main__':
+    init()

--- a/temptest_command.py
+++ b/temptest_command.py
@@ -1,0 +1,62 @@
+from commands import loader as command_loader
+from commands.command_base import AbstractCommand
+
+from bot_functions import utilities_db as db_utility
+
+
+loadedCommands = {}
+
+
+def db_setup():
+    db_obj = db_utility.Praxis_DB_Connection(autoConnect=True)
+    db_obj.dbConnection.execute('DROP TABLE command_responses_v0')
+    if db_obj.doesTableExist("command_responses_v0") == False:
+        print("Making Table")
+        results = db_obj.execQuery(
+            'CREATE TABLE command_responses_v0 ('
+            'id SERIAL, '
+            'command TEXT, '
+            'response TEXT);')
+    db_obj.closeConnection()
+
+
+def create_basicCommands():
+    db_obj = db_utility.Praxis_DB_Connection(autoConnect=True)
+    if db_obj.doesTableExist("command_responses_v0") == True:
+        results = db_obj.execQuery(
+            'INSERT INTO command_responses_v0 '
+            '(command, response) '
+            'VALUES (\'test\',\'This is a $(test) command @(user)\');'
+            )
+        print(results)
+    db_obj.closeConnection()
+
+
+def init():
+    # todo load entire command library and cache it here
+    load_commands()
+
+def load_commands():
+    global loadedCommands
+    loadedCommands = command_loader.load_commands(AbstractCommand.CommandType.Ver3)
+
+def handle_command(command, argz):
+    cmd:AbstractCommand = loadedCommands[command]
+    if cmd is not None:
+        cmd_response = cmd.do_command(
+            AbstractCommand.CommandSource.default,
+            "test_user",
+            command,
+            argz,
+            None)
+        return cmd_response
+    else:
+        return None
+
+if __name__ == '__main__':
+    db_setup()
+
+    create_basicCommands()
+    init()
+
+    #results = handle_command("!test", "")


### PR DESCRIPTION
Adding the ability for commands to run several functions based on the returnString they will need to provide.
```
Example:
Idea: "!roll #(0)" = "!roll d20"
Command = "!roll"
Rest = " #(0)" = " d20"

Example returnString: 
"@(user) rolled $(roll #(0))"
```

Currently I plan on having functions, variables, and arguments being added to the returnString, which will replace that part of the string with the correct response/value.
$(FUNCTION_NAME)
@(VARIABLE_NAME)
#(ARGUMENT_INDEX)

The idea is that you can nest these inside of each other for more complex commands.