### PR TITLE
New functions

### DIFF
--- a/commands/implemented_functions/function_curUnixTime.py
+++ b/commands/implemented_functions/function_curUnixTime.py
@@ -35,15 +35,13 @@ from commands.command_functions import Abstract_Function_Helpers
 
 from bot_functions import utilities_script as utility
 
-from datetime import datetime
-
-from dateutil.parser import parse as parse_date
+import time
 
 class Function_GetUnixTime(AbstractCommandFunction, metaclass=ABCMeta):
     """
     This is v0 of Functions
     """
-    functionName = "getUnixTime"
+    functionName = "curUnixTime"
     helpText = ["This is a v0 function.",
         "\nExample:","testFunction"]
 
@@ -62,6 +60,5 @@ class Function_GetUnixTime(AbstractCommandFunction, metaclass=ABCMeta):
         return output
 
     def do_work(self, user, functionName, args, bonusData):
-        inputArgs = " ".join(args)
 
-        return str(int(parse_date(inputArgs).timestamp()))
+        return str(int(time.time()))

--- a/commands/implemented_functions/function_getAverageBitrate.py
+++ b/commands/implemented_functions/function_getAverageBitrate.py
@@ -1,0 +1,96 @@
+# The main repository of Praxis Bot can be found at: <https://github.com/TheCuriousNerd/Praxis-Bot>.
+# Copyright (C) 2021
+
+# Author Info Examples:
+#   Name / Email / Website
+#       Twitter / Twitch / Youtube / Github
+
+# Authors:
+#   Alex Orid / inquiries@thecuriousnerd.com / TheCuriousNerd.com
+#       Twitter: @TheCuriousNerd / Twitch: TheCuriousNerd / Youtube: thecuriousnerd / Github: TheCuriousNerd
+
+# This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from abc import ABCMeta
+from ast import arg
+
+from json import loads
+from urllib.parse import urlencode
+import requests
+
+from commands.command_base import AbstractCommand
+from commands.command_functions import AbstractCommandFunction
+
+from commands.command_functions import Abstract_Function_Helpers
+
+from bot_functions import utilities_script as utility
+
+import simpleobsws
+import config
+
+class Function_GetBitrate(AbstractCommandFunction, metaclass=ABCMeta):
+    """
+    This is v0 of Functions
+    """
+    functionName = "getAverageBitrate"
+    helpText = ["This is a v0 function.",
+        "\nExample:","testFunction"]
+
+    def __init__(self):
+        super().__init__(
+            functionName = Function_GetBitrate.functionName,
+            n_args = 0,
+            functionType = AbstractCommandFunction.FunctionType.ver0,
+            helpText = Function_GetBitrate.helpText,
+            bonusFunctionData = None
+            )
+
+    def do_function(self, tokenSource, user, functionName, args, bonusData):
+        output = self.do_work(user, functionName, args, bonusData)
+
+        return output
+
+    def do_work(self, user, functionName, args, bonusData):
+
+        try:
+            from bot_functions import obsWebSocket as obsWebSocket
+            output:simpleobsws.RequestResponse = obsWebSocket.makeRequest("GetStreamStatus", {})
+            print(output)
+            if output.responseData.get("outputBytes", None) == None:
+                return "[Is OBS Running?]"
+            if output.responseData.get("outputDuration", None) == None:
+                return "[Is OBS Running?]"
+            if output.responseData.get("outputReconnecting", None) == None:
+                return "[Is OBS Running?]"
+
+            if output.responseData.get("outputReconnecting", None) == True:
+                return " OBS is Reconnecting"
+
+            total_duration_miliseconds = output.responseData.get("outputDuration", 0)
+            total_bytes = output.responseData.get("outputBytes", 0)
+            selected_interval = 30
+
+            if total_duration_miliseconds != 0:
+                # Calculate the bitrate
+                bitrate = (total_bytes*8) / (total_duration_miliseconds/1000)
+                bitrate_kbs = bitrate / 1000
+                return "Average Bitrate: %s kbs" % (int(bitrate_kbs))
+
+
+
+        except Exception as e:
+            # todo handle exceptions
+            return str(e)
+
+        return ""

--- a/commands/implemented_functions/function_getUnixTime.py
+++ b/commands/implemented_functions/function_getUnixTime.py
@@ -37,6 +37,8 @@ from bot_functions import utilities_script as utility
 
 from datetime import datetime
 
+from dateutil import tz
+from dateutil import zoneinfo
 from dateutil.parser import parse as parse_date
 
 class Function_GetUnixTime(AbstractCommandFunction, metaclass=ABCMeta):
@@ -64,4 +66,4 @@ class Function_GetUnixTime(AbstractCommandFunction, metaclass=ABCMeta):
     def do_work(self, user, functionName, args, bonusData):
         inputArgs = " ".join(args)
 
-        return str(int(parse_date(inputArgs).timestamp()))
+        return str(int(parse_date(inputArgs, ignoretz=False).timestamp()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ numexpr
 paramiko
 youtube_dl
 simpleobsws
+python-dateutil

--- a/requirements_sa_command.txt
+++ b/requirements_sa_command.txt
@@ -15,3 +15,4 @@ gTTS
 playsound
 simpleeval==0.9.12
 simpleobsws
+python-dateutil


### PR DESCRIPTION
Added:

$curUnixTime
-Feed it a string and it will parse to UNIX time.

$getAverageBitrate (EXPERIMENTAL)
-This is super limited because OBS Websockets cannot get the current bitrate output from OBS. This currently outputs the average bitrate for the whole stream.